### PR TITLE
Fix a couple of details

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Build an SVG sprite with Webpack and [svg-sprite](https://github.com/jkphl/svg-s
 ```javascript
 import path from 'path';
 import webpack from 'webpack';
-import WebpackSVGSpritePlugin from 'webpack-svg-sprite';
+import WebpackSVGSpritePlugin from 'webpack-svg-sprite-plugin';
 import icons from './svg-sprite.js';
 ...
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ It's up to you to include the sprite in your app now, but once you've got it, yo
 |**context**|`String`|`'./icons'`|The path to the folder containing the separate SVG icon files.|
 |**dest**|`String`|`'./dist'`|The path to the output folder where the generated SVG sprite file will be placed.|
 |**filename**|`String`|`'sprite.svg'` <br>or the name of the config file if `options.icons` is a string.|The name of the generated SVG sprite file. (i.e. `'svg-sprite.svg'`|
+|**config**|`Object`|`{}`|Specific options to pass to [svg-sprite](https://github.com/jkphl/svg-sprite) constructor|

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-import SVGSpriter from 'svg-sprite';
-import mkdirp from 'mkdirp';
-import path from 'path';
-import fs from 'fs';
+const SVGSpriter = require('svg-sprite');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const fs = require('fs');
 
-export default class WebpackSVGSpritePlugin {
+class WebpackSVGSpritePlugin {
     constructor({
         icons = [],
         context = path.resolve(__dirname, 'icons'),
@@ -69,3 +69,5 @@ export default class WebpackSVGSpritePlugin {
         });
     }
 }
+
+module.exports = WebpackSVGSpritePlugin;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ export default class WebpackSVGSpritePlugin {
         icons = [],
         context = path.resolve(__dirname, 'icons'),
         dest = path.resolve(__dirname, 'dist'),
-        filename = null
+        filename = null,
+        config = {}
     } = {}) {
         if (typeof icons === 'string') {
             let iconImport = require(icons);
@@ -29,11 +30,12 @@ export default class WebpackSVGSpritePlugin {
             ? this.iconsFile.slice(this.iconsFile.lastIndexOf('/') + 1, this.iconsFile.lastIndexOf('.'))
             : 'sprite') + '.svg';
         this.dest = dest;
+        this.config = config;
     }
     apply(compiler) {
         compiler.plugin('after-emit', (compilation, callback) => {
             if (this.icons.length > 0) {
-                const spriter = new SVGSpriter({
+                const spriter = new SVGSpriter(Object.assign({
                     dest: 'out',
                     mode: {
                         inline: true,
@@ -42,7 +44,7 @@ export default class WebpackSVGSpritePlugin {
                             sprite: this.filename
                         }
                     }
-                });
+                }, this.config));
 
                 this.icons.forEach(icon => {
                     const svgFilename = `${icon}.svg`;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export default class WebpackSVGSpritePlugin {
         this.config = config;
     }
     apply(compiler) {
-        compiler.plugin('after-emit', (compilation, callback) => {
+        compiler.hooks.afterEmit.tapAsync('SVGSprite', (compilation, callback) => {
             if (this.icons.length > 0) {
                 const spriter = new SVGSpriter(Object.assign({
                     dest: 'out',


### PR DESCRIPTION
- Add direct support for `svg-sprite` constructor options
- Migrate compiler pass syntax to Webpack 5
- Use CommonJS modules rather than ES6 to support more Node.js versions
- Fix import name in documentation example